### PR TITLE
feat(dynamodb) Move to use query instead of scan

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,10 @@
+steps:
+  - name: ":golang:"
+    command: "make ci"
+    env:
+      CB_IMAGE_OVERRIDE: "wolfeidau/buildkite-golang:1.12"
+      CB_COMPUTE_TYPE_OVERRIDE: "BUILD_GENERAL1_SMALL"
+      GO111MODULE: "on"
+    agents:
+      queue: dev
+      serverless: true

--- a/README.md
+++ b/README.md
@@ -10,25 +10,28 @@ The main interfaces are as follows.
 // Store represents the backend K/V storage
 type Store interface {
 	// Put a value at the specified key
-	Put(key string, value []byte, options WriteOptions) error
+	Put(key string, value []byte, options *WriteOptions) error
 
 	// Get a value given its key
-	Get(key string, options ReadOptions) (*KVPair, error)
+	Get(key string, options *ReadOptions) (*KVPair, error)
+
+	// List the content of a given prefix
+	List(prefix string, options *ReadOptions) ([]*KVPair, error)
 
 	// Delete the value at the specified key
 	Delete(key string) error
 
 	// Verify if a Key exists in the store
-	Exists(key string, options ReadOptions) (bool, error)
+	Exists(key string, options *ReadOptions) (bool, error)
 
 	// NewLock creates a lock for a given key.
 	// The returned Locker is not held and must be acquired
 	// with `.Lock`. The Value is optional.
-	NewLock(key string, options LockOptions) (Locker, error)
+	NewLock(key string, options *LockOptions) (Locker, error)
 
 	// Atomic CAS operation on a single value.
 	// Pass previous = nil to create a new key.
-	AtomicPut(key string, value []byte, previous *KVPair, options WriteOptions) (bool, *KVPair, error)
+	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
 
 	// Atomic delete of a single value
 	AtomicDelete(key string, previous *KVPair) (bool, error)


### PR DESCRIPTION
In general, Scan operations are less efficient than other operations in DynamoDB.

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-query-scan.html