### PR TITLE
refactor(api) Use variadic options to simplify api

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,28 @@ The main interfaces are as follows.
 // Store represents the backend K/V storage
 type Store interface {
 	// Put a value at the specified key
-	Put(key string, value []byte, options *WriteOptions) error
+	Put(key string, options ...WriteOption) error
 
 	// Get a value given its key
-	Get(key string, options *ReadOptions) (*KVPair, error)
+	Get(key string, options ...ReadOption) (*KVPair, error)
 
 	// List the content of a given prefix
-	List(prefix string, options *ReadOptions) ([]*KVPair, error)
+	List(prefix string, options ...ReadOption) ([]*KVPair, error)
 
 	// Delete the value at the specified key
 	Delete(key string) error
 
 	// Verify if a Key exists in the store
-	Exists(key string, options *ReadOptions) (bool, error)
+	Exists(key string, options ...ReadOption) (bool, error)
 
 	// NewLock creates a lock for a given key.
 	// The returned Locker is not held and must be acquired
 	// with `.Lock`. The Value is optional.
-	NewLock(key string, options *LockOptions) (Locker, error)
+	NewLock(key string, options ...LockOption) (Locker, error)
 
 	// Atomic CAS operation on a single value.
 	// Pass previous = nil to create a new key.
-	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
+	AtomicPut(key string, options ...WriteOption) (bool, *KVPair, error)
 
 	// Atomic delete of a single value
 	AtomicDelete(key string, previous *KVPair) (bool, error)

--- a/dynalock.go
+++ b/dynalock.go
@@ -1,8 +1,19 @@
 package dynalock
 
 import (
+	"encoding/base64"
 	"errors"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+const (
+	// DefaultLockTTL default duration for locks
+	DefaultLockTTL = 20 * time.Second
+
+	listDefaultTimeout = 5 * time.Second
 )
 
 var (
@@ -17,36 +28,33 @@ var (
 
 	// ErrLockAcquireCancelled lock acquire was cancelled
 	ErrLockAcquireCancelled = errors.New("lock acquire was cancelled")
-
-	defaultLockTTL     = 20 * time.Second
-	listDefaultTimeout = 5 * time.Second
 )
 
 // Store represents the backend K/V storage
 type Store interface {
 	// Put a value at the specified key
-	Put(key string, value []byte, options *WriteOptions) error
+	Put(key string, options ...WriteOption) error
 
 	// Get a value given its key
-	Get(key string, options *ReadOptions) (*KVPair, error)
+	Get(key string, options ...ReadOption) (*KVPair, error)
 
 	// List the content of a given prefix
-	List(prefix string, options *ReadOptions) ([]*KVPair, error)
+	List(prefix string, options ...ReadOption) ([]*KVPair, error)
 
 	// Delete the value at the specified key
 	Delete(key string) error
 
 	// Verify if a Key exists in the store
-	Exists(key string, options *ReadOptions) (bool, error)
+	Exists(key string, options ...ReadOption) (bool, error)
 
 	// NewLock creates a lock for a given key.
 	// The returned Locker is not held and must be acquired
 	// with `.Lock`. The Value is optional.
-	NewLock(key string, options *LockOptions) (Locker, error)
+	NewLock(key string, options ...LockOption) (Locker, error)
 
 	// Atomic CAS operation on a single value.
 	// Pass previous = nil to create a new key.
-	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
+	AtomicPut(key string, options ...WriteOption) (bool, *KVPair, error)
 
 	// Atomic delete of a single value
 	AtomicDelete(key string, previous *KVPair) (bool, error)
@@ -59,19 +67,134 @@ type Locker interface {
 	Unlock() error
 }
 
+// WriteOption assign various settings to the write options
+type WriteOption func(opts *WriteOptions)
+
 // WriteOptions contains optional request parameters
 type WriteOptions struct {
-	TTL time.Duration
+	value    *dynamodb.AttributeValue
+	ttl      time.Duration
+	previous *KVPair // Optional, previous value used to assert if the record has been modified before an atomic update
 }
+
+// NewWriteOptions create write options, assign defaults then accept overrides
+func NewWriteOptions(opts ...WriteOption) *WriteOptions {
+
+	writeOpts := &WriteOptions{
+		ttl: DefaultLockTTL,
+	}
+
+	for _, opt := range opts {
+		opt(writeOpts)
+	}
+
+	return writeOpts
+}
+
+// WriteWithTTL time to live (TTL) to the key which is written
+func WriteWithTTL(ttl time.Duration) WriteOption {
+	return func(opts *WriteOptions) {
+		opts.ttl = ttl
+	}
+}
+
+// WriteWithBytes byte slice to the key which is written
+func WriteWithBytes(val []byte) WriteOption {
+	return func(opts *WriteOptions) {
+		opts.value = encodePayload(val)
+	}
+}
+
+// WriteWithAttributeValue dynamodb attribute value which is written
+func WriteWithAttributeValue(av *dynamodb.AttributeValue) WriteOption {
+	return func(opts *WriteOptions) {
+		opts.value = av
+	}
+}
+
+// WriteWithPreviousKV previous KV which will be checked prior to update
+func WriteWithPreviousKV(previous *KVPair) WriteOption {
+	return func(opts *WriteOptions) {
+		opts.previous = previous
+	}
+}
+
+// ReadOption assign various settings to the read options
+type ReadOption func(opts *ReadOptions)
 
 // ReadOptions contains optional request parameters
 type ReadOptions struct {
-	Consistent bool
+	consistent bool
 }
+
+// NewReadOptions create read options, assign defaults then accept overrides
+// enable the read consistent flag by default
+func NewReadOptions(opts ...ReadOption) *ReadOptions {
+
+	readOpts := &ReadOptions{
+		consistent: true,
+	}
+
+	for _, opt := range opts {
+		opt(readOpts)
+	}
+
+	return readOpts
+}
+
+// ReadWithConsistent enable consistent reads
+func ReadConsistentDisable() ReadOption {
+	return func(opts *ReadOptions) {
+		opts.consistent = false
+	}
+}
+
+// LockOption assign various settings to the lock options
+type LockOption func(opts *LockOptions)
 
 // LockOptions contains optional request parameters
 type LockOptions struct {
-	Value     []byte        // Optional, value to associate with the lock
-	TTL       time.Duration // Optional, expiration ttl associated with the lock
-	RenewLock chan struct{} // Optional, chan used to control and stop the session ttl renewal for the lock
+	value     *dynamodb.AttributeValue
+	ttl       time.Duration
+	renewLock chan struct{}
+}
+
+// NewLockOptions create lock options, assign defaults then accept overrides
+func NewLockOptions(opts ...LockOption) *LockOptions {
+
+	lockOpts := &LockOptions{
+		ttl: DefaultLockTTL,
+	}
+
+	for _, opt := range opts {
+		opt(lockOpts)
+	}
+
+	return lockOpts
+}
+
+// LockWithBytes byte slice to the key which is written when the lock is  acquired
+func LockWithBytes(val []byte) LockOption {
+	return func(opts *LockOptions) {
+		opts.value = encodePayload(val)
+	}
+}
+
+// LockWithTTL time to live (TTL) to the key which is written when the lock is acquired
+func LockWithTTL(ttl time.Duration) LockOption {
+	return func(opts *LockOptions) {
+		opts.ttl = ttl
+	}
+}
+
+// LockWithRenewLock renewal channel to the lock
+func LockWithRenewLock(renewLockChan chan struct{}) LockOption {
+	return func(opts *LockOptions) {
+		opts.renewLock = renewLockChan
+	}
+}
+
+func encodePayload(payload []byte) *dynamodb.AttributeValue {
+	encodedValue := base64.StdEncoding.EncodeToString(payload)
+	return &dynamodb.AttributeValue{S: aws.String(encodedValue)}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.12
 require (
 	github.com/aws/aws-sdk-go v1.19.11
 	github.com/dhui/dktest v0.3.0
-	github.com/sirupsen/logrus v1.2.0
 	github.com/stretchr/testify v1.2.2
+	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190102155601-82a175fd1598 h1:S8GOgffXV1X3fpVG442QRfWOt0iFl79eHJ7OPt725bo=


### PR DESCRIPTION
* make the internals of the options private
    
This is based on https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
