### PR TITLE
fix(write) Fix to ensure existing TTL remains for kv

### DIFF
--- a/dynalock.go
+++ b/dynalock.go
@@ -1,12 +1,8 @@
 package dynalock
 
 import (
-	"encoding/base64"
 	"errors"
 	"time"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 const (
@@ -14,6 +10,8 @@ const (
 	DefaultLockTTL = 20 * time.Second
 
 	listDefaultTimeout = 5 * time.Second
+
+	noTTLSet = -1
 )
 
 var (
@@ -69,143 +67,4 @@ type Locker interface {
 
 	// Unlock this will unlock and perfom a DELETE to remove the store record
 	Unlock() error
-}
-
-// WriteOption assign various settings to the write options
-type WriteOption func(opts *WriteOptions)
-
-// WriteOptions contains optional request parameters
-type WriteOptions struct {
-	value    *dynamodb.AttributeValue
-	ttl      time.Duration
-	previous *KVPair // Optional, previous value used to assert if the record has been modified before an atomic update
-}
-
-// NewWriteOptions create write options, assign defaults then accept overrides
-func NewWriteOptions(opts ...WriteOption) *WriteOptions {
-
-	writeOpts := &WriteOptions{
-		ttl: DefaultLockTTL,
-	}
-
-	for _, opt := range opts {
-		opt(writeOpts)
-	}
-
-	return writeOpts
-}
-
-// WriteWithTTL time to live (TTL) to the key which is written
-func WriteWithTTL(ttl time.Duration) WriteOption {
-	return func(opts *WriteOptions) {
-		opts.ttl = ttl
-	}
-}
-
-// WriteWithNoExpires time to live (TTL) is set not set so it never expires
-func WriteWithNoExpires() WriteOption {
-	return func(opts *WriteOptions) {
-		opts.ttl = 0
-	}
-}
-
-// WriteWithBytes byte slice to the key which is written
-func WriteWithBytes(val []byte) WriteOption {
-	return func(opts *WriteOptions) {
-		opts.value = encodePayload(val)
-	}
-}
-
-// WriteWithAttributeValue dynamodb attribute value which is written
-func WriteWithAttributeValue(av *dynamodb.AttributeValue) WriteOption {
-	return func(opts *WriteOptions) {
-		opts.value = av
-	}
-}
-
-// WriteWithPreviousKV previous KV which will be checked prior to update
-func WriteWithPreviousKV(previous *KVPair) WriteOption {
-	return func(opts *WriteOptions) {
-		opts.previous = previous
-	}
-}
-
-// ReadOption assign various settings to the read options
-type ReadOption func(opts *ReadOptions)
-
-// ReadOptions contains optional request parameters
-type ReadOptions struct {
-	consistent bool
-}
-
-// NewReadOptions create read options, assign defaults then accept overrides
-// enable the read consistent flag by default
-func NewReadOptions(opts ...ReadOption) *ReadOptions {
-
-	readOpts := &ReadOptions{
-		consistent: true,
-	}
-
-	for _, opt := range opts {
-		opt(readOpts)
-	}
-
-	return readOpts
-}
-
-// ReadConsistentDisable disable consistent reads
-func ReadConsistentDisable() ReadOption {
-	return func(opts *ReadOptions) {
-		opts.consistent = false
-	}
-}
-
-// LockOption assign various settings to the lock options
-type LockOption func(opts *LockOptions)
-
-// LockOptions contains optional request parameters
-type LockOptions struct {
-	value     *dynamodb.AttributeValue
-	ttl       time.Duration
-	renewLock chan struct{}
-}
-
-// NewLockOptions create lock options, assign defaults then accept overrides
-func NewLockOptions(opts ...LockOption) *LockOptions {
-
-	lockOpts := &LockOptions{
-		ttl: DefaultLockTTL,
-	}
-
-	for _, opt := range opts {
-		opt(lockOpts)
-	}
-
-	return lockOpts
-}
-
-// LockWithBytes byte slice to the key which is written when the lock is  acquired
-func LockWithBytes(val []byte) LockOption {
-	return func(opts *LockOptions) {
-		opts.value = encodePayload(val)
-	}
-}
-
-// LockWithTTL time to live (TTL) to the key which is written when the lock is acquired
-func LockWithTTL(ttl time.Duration) LockOption {
-	return func(opts *LockOptions) {
-		opts.ttl = ttl
-	}
-}
-
-// LockWithRenewLock renewal channel to the lock
-func LockWithRenewLock(renewLockChan chan struct{}) LockOption {
-	return func(opts *LockOptions) {
-		opts.renewLock = renewLockChan
-	}
-}
-
-func encodePayload(payload []byte) *dynamodb.AttributeValue {
-	encodedValue := base64.StdEncoding.EncodeToString(payload)
-	return &dynamodb.AttributeValue{S: aws.String(encodedValue)}
 }

--- a/dynamodb.go
+++ b/dynamodb.go
@@ -217,6 +217,12 @@ func (ddb *Dynalock) AtomicPut(key string, options ...WriteOption) (bool, *KVPai
 
 	writeOptions := NewWriteOptions(options...)
 
+	// if writeOptions.previous != nil {
+	// 	if writeOptions.ttl == DefaultLockTTL {
+	// 		writeOptions.ttl = writeOptions.previous.Expires
+	// 	}
+	// }
+
 	params := ddb.buildUpdateItemInput(key, writeOptions)
 
 	err := updateWithConditions(params, writeOptions.previous)

--- a/options.go
+++ b/options.go
@@ -1,0 +1,156 @@
+package dynalock
+
+import (
+	"encoding/base64"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+// WriteOption assign various settings to the write options
+type WriteOption func(opts *WriteOptions)
+
+// WriteOptions contains optional request parameters
+type WriteOptions struct {
+	value    *dynamodb.AttributeValue
+	ttl      time.Duration
+	previous *KVPair // Optional, previous value used to assert if the record has been modified before an atomic update
+}
+
+// NewWriteOptions create write options, assign defaults then accept overrides
+func NewWriteOptions(opts ...WriteOption) *WriteOptions {
+
+	// assign a place holder value to detect whether to assign the default TTL
+	writeOpts := &WriteOptions{
+		ttl: noTTLSet,
+	}
+
+	for _, opt := range opts {
+		opt(writeOpts)
+	}
+
+	if writeOpts.ttl == noTTLSet {
+		writeOpts.ttl = DefaultLockTTL
+	}
+
+	return writeOpts
+}
+
+// WriteWithTTL time to live (TTL) to the key which is written
+func WriteWithTTL(ttl time.Duration) WriteOption {
+	return func(opts *WriteOptions) {
+		opts.ttl = ttl
+	}
+}
+
+// WriteWithNoExpires time to live (TTL) is set not set so it never expires
+func WriteWithNoExpires() WriteOption {
+	return func(opts *WriteOptions) {
+		opts.ttl = 0
+	}
+}
+
+// WriteWithBytes byte slice to the key which is written
+func WriteWithBytes(val []byte) WriteOption {
+	return func(opts *WriteOptions) {
+		opts.value = encodePayload(val)
+	}
+}
+
+// WriteWithAttributeValue dynamodb attribute value which is written
+func WriteWithAttributeValue(av *dynamodb.AttributeValue) WriteOption {
+	return func(opts *WriteOptions) {
+		opts.value = av
+	}
+}
+
+// WriteWithPreviousKV previous KV which will be checked prior to update
+func WriteWithPreviousKV(previous *KVPair) WriteOption {
+	return func(opts *WriteOptions) {
+		opts.previous = previous
+		if opts.previous != nil {
+			opts.ttl = time.Until(time.Unix(opts.previous.Expires, 0)) // update the TTL to the remaining time
+		}
+	}
+}
+
+// ReadOption assign various settings to the read options
+type ReadOption func(opts *ReadOptions)
+
+// ReadOptions contains optional request parameters
+type ReadOptions struct {
+	consistent bool
+}
+
+// NewReadOptions create read options, assign defaults then accept overrides
+// enable the read consistent flag by default
+func NewReadOptions(opts ...ReadOption) *ReadOptions {
+
+	readOpts := &ReadOptions{
+		consistent: true,
+	}
+
+	for _, opt := range opts {
+		opt(readOpts)
+	}
+
+	return readOpts
+}
+
+// ReadConsistentDisable disable consistent reads
+func ReadConsistentDisable() ReadOption {
+	return func(opts *ReadOptions) {
+		opts.consistent = false
+	}
+}
+
+// LockOption assign various settings to the lock options
+type LockOption func(opts *LockOptions)
+
+// LockOptions contains optional request parameters
+type LockOptions struct {
+	value     *dynamodb.AttributeValue
+	ttl       time.Duration
+	renewLock chan struct{}
+}
+
+// NewLockOptions create lock options, assign defaults then accept overrides
+func NewLockOptions(opts ...LockOption) *LockOptions {
+
+	lockOpts := &LockOptions{
+		ttl: DefaultLockTTL,
+	}
+
+	for _, opt := range opts {
+		opt(lockOpts)
+	}
+
+	return lockOpts
+}
+
+// LockWithBytes byte slice to the key which is written when the lock is  acquired
+func LockWithBytes(val []byte) LockOption {
+	return func(opts *LockOptions) {
+		opts.value = encodePayload(val)
+	}
+}
+
+// LockWithTTL time to live (TTL) to the key which is written when the lock is acquired
+func LockWithTTL(ttl time.Duration) LockOption {
+	return func(opts *LockOptions) {
+		opts.ttl = ttl
+	}
+}
+
+// LockWithRenewLock renewal channel to the lock
+func LockWithRenewLock(renewLockChan chan struct{}) LockOption {
+	return func(opts *LockOptions) {
+		opts.renewLock = renewLockChan
+	}
+}
+
+func encodePayload(payload []byte) *dynamodb.AttributeValue {
+	encodedValue := base64.StdEncoding.EncodeToString(payload)
+	return &dynamodb.AttributeValue{S: aws.String(encodedValue)}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,31 @@
+package dynalock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWriteOptions(t *testing.T) {
+	assert := require.New(t)
+
+	opts := NewWriteOptions()
+
+	assert.Equal(&WriteOptions{ttl: DefaultLockTTL}, opts)
+}
+
+func TestNewWriteOptionsWithPreviousKV(t *testing.T) {
+	assert := require.New(t)
+
+	dt := time.Now().Add(60 * time.Second)
+
+	kv := &KVPair{Expires: dt.Unix()}
+
+	opts := NewWriteOptions(WriteWithPreviousKV(kv))
+
+	expected := &WriteOptions{ttl: time.Until(dt), previous: kv}
+
+	assert.Equal(expected.previous, opts.previous)
+	assert.WithinDuration(time.Now().Add(expected.ttl), time.Now().Add(opts.ttl), 1*time.Second)
+}


### PR DESCRIPTION
If the previous value was supplied, but a new TTL wasn't then the new expiry was based on the defaultLockTTL, which is incorrect. It now uses the existing value.

Also added a test for to ensure TTL is applied correctly on create.