### PR TITLE
feat(locking): added with context lock and used done for stop

### DIFF
--- a/dynalock.go
+++ b/dynalock.go
@@ -1,6 +1,7 @@
 package dynalock
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -64,6 +65,9 @@ type Store interface {
 type Locker interface {
 	// Lock attempt to lock the store record, this will BLOCK and retry at a rate of once every 3 seconds
 	Lock(stopChan chan struct{}) (<-chan struct{}, error)
+
+	// Lock attempt to lock the store record, this will BLOCK and retry at a rate of once every 3 seconds
+	LockWithContext(ctx context.Context) (<-chan struct{}, error)
 
 	// Unlock this will unlock and perfom a DELETE to remove the store record
 	Unlock() error

--- a/dynamodb_test.go
+++ b/dynamodb_test.go
@@ -57,7 +57,7 @@ func Test_buildUpdateItemInput(t *testing.T) {
 
 	expectedUpdate := dynamodb.UpdateItemInput{
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
-			":inc": &dynamodb.AttributeValue{
+			":inc": {
 				N: aws.String("1"),
 			},
 			":ttl": {
@@ -65,10 +65,10 @@ func Test_buildUpdateItemInput(t *testing.T) {
 			},
 		},
 		Key: map[string]*dynamodb.AttributeValue{
-			"id": &dynamodb.AttributeValue{
+			"id": {
 				S: aws.String("test"),
 			},
-			"name": &dynamodb.AttributeValue{
+			"name": {
 				S: aws.String("abc123"),
 			},
 		},


### PR DESCRIPTION
This provides an alternative to the channel based API which is better for short term locks in an HTTP service.