### PR TITLE
feat(locking): added options to disable renewal and polling

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.16
       id: go
 
     - name: Check out code into the Go module directory

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ bin/golangci-lint-${GOLANGCI_VERSION}:
 
 test: ##=> Run the tests
 	$(info [+] Run tests...")
-	@go test -v -cover ./...
+	@go test -v -race -cover ./...
 .PHONY: test
 
 lintv2: bin/golangci-lint ##=> Lint all the v2 things

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ The main problems I am trying to solve in with this package are:
 
 Some examples of uses for a library like this are:
 
-1. When using scheduled lambda functions this library will enable you to lock resources before performing actions with it, this could be a payment api or a ECS cluster, either way it is important to ensure only ONE service is performing that task at one time.
-2. When you start using step functions, how can you ensure only one workflow is active and performing some task, like provisioning, without having to worry about parallel executions.
+1. Locking a logical resource in your system while you make some updates, especially if this involves a few AWS resources, such as DynamoDB, S3 and SSM in one change.
+2. When using scheduled lambda functions this library will enable you to lock resources before performing actions with it, this could be a payment api or a ECS cluster, either way it is important to ensure only ONE service is performing that task at one time.
+3. When you start using step functions, how can you ensure only one workflow is active and performing some task, like provisioning, without having to worry about parallel executions.
 
 So the key here is storing state, and coordinating changes across workers, or resources.
 

--- a/dynalock.go
+++ b/dynalock.go
@@ -27,6 +27,9 @@ var (
 
 	// ErrLockAcquireCancelled lock acquire was cancelled
 	ErrLockAcquireCancelled = errors.New("lock acquire was cancelled")
+
+	// ErrLockAcquireFailed lock acquire failed due with polling disabled
+	ErrLockAcquireFailed = errors.New("failed to acquire lock")
 )
 
 // Store represents the backend K/V storage

--- a/dynamodb.go
+++ b/dynamodb.go
@@ -366,13 +366,15 @@ func (ddb *Dynalock) NewLock(key string, options ...LockOption) (Locker, error) 
 	}
 
 	return &dynamodbLock{
-		ddb:      ddb,
-		last:     nil,
-		key:      key,
-		value:    value,
-		ttl:      ttl,
-		renewCh:  renewCh,
-		unlockCh: unlockCh,
+		ddb:                  ddb,
+		last:                 nil,
+		key:                  key,
+		value:                value,
+		ttl:                  ttl,
+		renewCh:              renewCh,
+		renewEnable:          lockOptions.renewEnable,
+		tryLockPollingEnable: lockOptions.tryLockPollingEnable,
+		unlockCh:             unlockCh,
 	}, nil
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -29,3 +29,12 @@ func TestNewWriteOptionsWithPreviousKV(t *testing.T) {
 	assert.Equal(expected.previous, opts.previous)
 	assert.WithinDuration(time.Now().Add(expected.ttl), time.Now().Add(opts.ttl), 1*time.Second)
 }
+
+func TestLockOptions(t *testing.T) {
+	assert := require.New(t)
+
+	lockOptions := NewLockOptions(LockWithNoRenew(), LockWithNoTryPolling())
+
+	assert.False(lockOptions.renewEnable)
+	assert.False(lockOptions.tryLockPollingEnable)
+}


### PR DESCRIPTION
This provides some options for locks which are issued with a once of TTL and more flexiblity in backoff when locking.

Also enabled race detection in tests.